### PR TITLE
Use `dyn` for trait objects

### DIFF
--- a/stm-core/src/transaction/log_var.rs
+++ b/stm-core/src/transaction/log_var.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-pub type ArcAny = Arc<Any + Send + Sync>;
+pub type ArcAny = Arc<dyn Any + Send + Sync>;
 
 /// `LogVar` is used by `Log` to track which `Var` was either read or written or both.
 /// Depending on the type, STM has to write, ensure consistency or block on this value.

--- a/stm-core/src/transaction/mod.rs
+++ b/stm-core/src/transaction/mod.rs
@@ -139,7 +139,7 @@ impl Transaction {
     }
 
     /// Perform a downcast on a var.
-    fn downcast<T: Any + Clone>(var: Arc<Any>) -> T {
+    fn downcast<T: Any + Clone>(var: Arc<dyn Any>) -> T {
         match var.downcast_ref::<T>() {
             Some(s) => s.clone(),
             None    => unreachable!("TVar has wrong type")

--- a/stm-core/src/tvar.rs
+++ b/stm-core/src/tvar.rs
@@ -49,7 +49,7 @@ pub struct VarControlBlock {
     ///
     /// Starvation may occur, if one thread wants to write-lock but others
     /// keep holding read-locks.
-    pub value: RwLock<Arc<Any + Send + Sync>>,
+    pub value: RwLock<Arc<dyn Any + Send + Sync>>,
 }
 
 
@@ -188,7 +188,7 @@ impl<T> TVar<T>
     pub fn read_atomic(&self) -> T {
         let val = self.read_ref_atomic();
 
-        (&*val as &Any)
+        (&*val as &dyn Any)
             .downcast_ref::<T>()
             .expect("wrong type in Var<T>")
             .clone()
@@ -199,7 +199,7 @@ impl<T> TVar<T>
     /// This is mostly used internally, but can be useful in
     /// some cases, because `read_atomic` clones the
     /// inner value, which may be expensive.
-    pub fn read_ref_atomic(&self) -> Arc<Any + Send + Sync> {
+    pub fn read_ref_atomic(&self) -> Arc<dyn Any + Send + Sync> {
         self.control_block
             .value
             .read()


### PR DESCRIPTION
Trait objects without an explicit `dyn` are deprecated and produce a warning. This changes all uses of trait objects to use `dyn`.